### PR TITLE
Run tracecompass-jdk17.Jenkins with sonar pod which has higher memory

### DIFF
--- a/jenkins/pipelines/tracecompass-jdk17.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-jdk17.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     agent {
         kubernetes {
             label 'tracecompass-build'
-            yamlFile 'jenkins/pod-templates/tracecompass-pod.yaml'
+            yamlFile 'jenkins/pod-templates/tracecompass-sonar-pod.yaml'
         }
     }
     options {


### PR DESCRIPTION
MAC notarization fails with Exit Code: 137, Reason: OOMKilled and this change will verify if more allocated memory will help.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>