### PR TITLE
Don't copy java doc in with verbose setting

### DIFF
--- a/scripts/deploy-javadoc.sh
+++ b/scripts/deploy-javadoc.sh
@@ -31,4 +31,4 @@ fi
 $ECHO ${SSH} "mkdir -p ${JAVADOC_DESTINATION} && \
               rm -rf ${JAVADOC_DESTINATION}/${JAVADOC_REPO}"
 
-$ECHO $SCP -rv ${javadocPath} "${SSHUSER}:${JAVADOC_DESTINATION}"
+$ECHO $SCP -r ${javadocPath} "${SSHUSER}:${JAVADOC_DESTINATION}"


### PR DESCRIPTION
This pollutes the build log and is not needed.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>