### PR TITLE
Update tracecompass-pod.yaml and tracecompass-jdk17.Jenkinsfile

### DIFF
--- a/jenkins/pipelines/tracecompass-jdk17.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-jdk17.Jenkinsfile
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2023 Ericsson.
+ * Copyright (c) 2019, 2024 Ericsson.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,7 +12,7 @@ pipeline {
     agent {
         kubernetes {
             label 'tracecompass-build'
-            yamlFile 'jenkins/pod-templates/tracecompass-sonar-pod.yaml'
+            yamlFile 'jenkins/pod-templates/tracecompass-pod.yaml'
         }
     }
     options {

--- a/jenkins/pod-templates/tracecompass-pod.yaml
+++ b/jenkins/pod-templates/tracecompass-pod.yaml
@@ -26,6 +26,13 @@ spec:
       mountPath: /opt/tools
   - name: jnlp
     image: 'eclipsecbi/jenkins-jnlp-agent'
+    resources:
+      requests:
+        memory: "1024Mi"
+        cpu: "500m"
+      limits:
+        memory: "1024Mi"
+        cpu: "500m"
     volumeMounts:
     - mountPath: /home/jenkins/.ssh
       name: volume-known-hosts

--- a/jenkins/pod-templates/tracecompass-pod.yaml
+++ b/jenkins/pod-templates/tracecompass-pod.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
   - name: tracecompass
-    image: eclipse/tracecompass-build-env:18.04
+    image: eclipse/tracecompass-build-env:22.04
     imagePullPolicy: Always
     tty: true
     command: [ "/bin/sh" ]


### PR DESCRIPTION
After successfully completing upgrading to tracecompass-build-env:22.04 for sonar builds update the main tracecompass-pod.yaml file as well. 

Additionally, allocate more resources for JNLP container so the file transfers have more resources by default.

Use tracecompass-pod.yaml in tracecompass-jdk17.Jenkinsfile because Sonar pod configuration is not needed for nightly builds.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>