### PR TITLE
tracecompass-build-env:18.04 for incubator builds

### DIFF
--- a/jenkins/pipelines/tracecompass-incubator-jdk17.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-incubator-jdk17.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     agent {
         kubernetes {
             label 'tracecompass-build'
-            yamlFile 'jenkins/pod-templates/tracecompass-pod.yaml'
+            yamlFile 'jenkins/pod-templates/tracecompass-incubator-sonar-pod.yaml'
         }
     }
     options {

--- a/jenkins/pipelines/tracecompass-incubator-sonar.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-incubator-sonar.Jenkinsfile
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2024 Ericsson.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+pipeline {
+    agent {
+        kubernetes {
+            label 'tracecompass-sonar-build'
+            yamlFile 'jenkins/pod-templates/tracecompass-incubator-sonar-pod.yaml'
+            defaultContainer 'tracecompass'
+        }
+    }
+    options {
+        timestamps()
+        timeout(time: 4, unit: 'HOURS')
+        disableConcurrentBuilds()
+    }
+    tools {
+        maven 'apache-maven-3.9.5'
+        jdk 'openjdk-jdk17-latest'
+    }
+    environment {
+        MAVEN_OPTS="-Xms768m -Xmx4096m -XX:+UseSerialGC"
+    }
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout([$class: 'GitSCM', branches: [[name: '$GERRIT_BRANCH_NAME']], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'BuildChooserSetting', buildChooser: [$class: 'GerritTriggerBuildChooser']]], submoduleCfg: [], userRemoteConfigs: [[refspec: '$GERRIT_REFSPEC', url: '$GERRIT_REPOSITORY_URL']]])
+            }
+        }
+        stage('Build') {
+            steps {
+                container('tracecompass') {
+                    sh 'mvn clean install -B -Pctf-grammar -Pbuild-rcp -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -Dmaven.repo.local=/home/jenkins/.m2/repository --settings /home/jenkins/.m2/settings.xml ${MAVEN_ARGS}'
+                }
+            }
+        }
+        stage('Sonar') {
+            steps {
+                container('tracecompass') {
+                    withCredentials([string(credentialsId: 'sonarcloud-token', variable: 'SONARCLOUD_TOKEN')]) {
+                        withSonarQubeEnv('SonarCloud.io') {
+                            sh 'mvn install -B jacoco:report sonar:sonar -Djacoco.dataFile=../../target/jacoco.exec -Dsonar.projectKey=${SONAR_PROJECT_KEY} -Dsonar.organization=eclipse -Dsonar.host.url=${SONAR_HOST_URL} -Dsonar.login=${SONARCLOUD_TOKEN} -Dmaven.test.error.ignore=true -Dmaven.test.failure.ignore=true -Dmaven.repo.local=/home/jenkins/.m2/repository --settings /home/jenkins/.m2/settings.xml'
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
+        failure {
+            container('tracecompass') {
+                emailext subject: 'Build $BUILD_STATUS: $PROJECT_NAME #$BUILD_NUMBER!',
+                body: '''$CHANGES \n
+------------------------------------------\n
+Check console output at $BUILD_URL to view the results.''',
+                recipientProviders: [culprits(), requestor()],
+                to: '${EMAIL_RECIPIENT}'
+            }
+        }
+        fixed {
+            container('tracecompass') {
+                emailext subject: 'Build is back to normal: $PROJECT_NAME #$BUILD_NUMBER!',
+                body: '''Check console output at $BUILD_URL to view the results.''',
+                recipientProviders: [culprits(), requestor()],
+                to: '${EMAIL_RECIPIENT}'
+            }
+        }
+    }
+}

--- a/jenkins/pod-templates/tracecompass-incubator-sonar-pod.yaml
+++ b/jenkins/pod-templates/tracecompass-incubator-sonar-pod.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: tracecompass
+    image: eclipse/tracecompass-build-env:18.04
+    imagePullPolicy: Always
+    tty: true
+    command: [ "/bin/sh" ]
+    args: ["-c", "/home/tracecompass/.vnc/xstartup.sh && cat"]
+    resources:
+      requests:
+        memory: "6Gi"
+        cpu: "2000m"
+      limits:
+        memory: "6Gi"
+        cpu: "2000m"
+    volumeMounts:
+    - name: settings-xml
+      mountPath: /home/jenkins/.m2/settings.xml
+      subPath: settings.xml
+      readOnly: true
+    - name: m2-repo
+      mountPath: /home/jenkins/.m2/repository
+    - name: tools
+      mountPath: /opt/tools
+  - name: jnlp
+    image: 'eclipsecbi/jenkins-jnlp-agent'
+    resources:
+      requests:
+        memory: "1024Mi"
+        cpu: "500m"
+      limits:
+        memory: "1024Mi"
+        cpu: "500m"
+    volumeMounts:
+    - mountPath: /home/jenkins/.ssh
+      name: volume-known-hosts
+  volumes:
+  - name: volume-known-hosts
+    configMap:
+      name: known-hosts
+  - name: settings-xml
+    secret:
+      secretName: m2-secret-dir
+      items:
+      - key: settings.xml
+        path: settings.xml
+  - name: m2-repo
+    emptyDir: {}
+  - name: tools
+    persistentVolumeClaim:
+      claimName: tools-claim-jiro-tracecompass


### PR DESCRIPTION
Python EASE scripting tests fail on tracecompass-build-env:22.04 due missing python setup in the new image.

Use old image until a new image is available with correct Python setup.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>