### PR TITLE
docker: Add symbolic link python -> python3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       metacity \
     && rm -rf /var/lib/apt/lists/* \
     && locale-gen en_US.UTF-8 \
-    && pip3 install --upgrade pip
+    && pip3 install --upgrade pip \
+    && ln-s /usr/bin/python3 /usr/bin/python
+
 # Need locale to be UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en


### PR DESCRIPTION
Needed for incubator EASE script tests for Python scripting engine.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>