### PR TITLE
Fix missing space when creating symbolic link for Python

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && locale-gen en_US.UTF-8 \
     && pip3 install --upgrade pip \
-    && ln-s /usr/bin/python3 /usr/bin/python
+    && ln -s /usr/bin/python3 /usr/bin/python
 
 # Need locale to be UTF-8
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>