### PR TITLE
Switch tracecompass-jdk17.Jenkinsfile to sonar pod configuration

### DIFF
--- a/jenkins/pipelines/tracecompass-jdk17.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-jdk17.Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     agent {
         kubernetes {
             label 'tracecompass-build'
-            yamlFile 'jenkins/pod-templates/tracecompass-pod.yaml'
+            yamlFile 'jenkins/pod-templates/tracecompass-sonar.yaml'
         }
     }
     options {


### PR DESCRIPTION
This increases memory and cpu allocation.

This is to test if build failures in ctf.u.swtbot.tests are fixed with this update.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>