### PR TITLE
Increase memory and cpu for default tracecompass-pod.yaml

### DIFF
--- a/jenkins/pod-templates/tracecompass-pod.yaml
+++ b/jenkins/pod-templates/tracecompass-pod.yaml
@@ -10,11 +10,11 @@ spec:
     args: ["-c", "/home/tracecompass/.vnc/xstartup.sh && cat"]
     resources:
       requests:
-        memory: "2.6Gi"
-        cpu: "1.3"
+        memory: "6Gi"
+        cpu: "2000m"
       limits:
-        memory: "2.6Gi"
-        cpu: "1.3"
+        memory: "6Gi"
+        cpu: "2000m"
     volumeMounts:
     - name: settings-xml
       mountPath: /home/jenkins/.m2/settings.xml


### PR DESCRIPTION
There has been intermittent job failures observed where the job is killed during ctf.core.tests.

The ERROR reported is "ERROR: script returned exit code 137" which points to memory problems.

Increase the memory to 6GB. Also, increase the CPU limits.

Note that Jenkins is not used for github pull request verification where 3 jobs run a the same time and hence the memory doesn't need to be restricted to 2.6GBi (and cpu 1.3) to not exceed the existing quota for the Trace Compass project.

The pull request verification is done through GitHub actions and is independent to the Trace Compass Jenkins configuration in this repo.

Note that GitHub actions don't have this memory issue, because the default GitHub runner has much more memory allocated than 2.6G.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>