### PR TITLE
Fix checkout step in Jenkins files without GerritTriggerBuildChoser

### DIFF
--- a/jenkins/pipelines/tracecompass-incubator-jdk17.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-incubator-jdk17.Jenkinsfile
@@ -51,11 +51,11 @@ pipeline {
                     sh 'cp scripts/deploy-javadoc.sh ${MAVEN_WORKSPACE_SCRIPTS}'
                     checkout([
                         $class: 'GitSCM', 
-                        branches: [[name: '$GERRIT_BRANCH_NAME']],
+                        branches: [[name: '*/$GERRIT_BRANCH_NAME']],
                         doGenerateSubmoduleConfigurations: false,
                         extensions: [],
                         submoduleCfg: [],
-                        userRemoteConfigs: [[credentialsId: 'github-bot', url: '$GERRIT_REPOSITORY_URL']]
+                        userRemoteConfigs: [[credentialsId: 'github-bot', refspec: '+refs/heads/$GERRIT_BRANCH_NAME:refs/remotes/origin/$GERRIT_BRANCH_NAME', url: '$GERRIT_REPOSITORY_URL']]
                     ])
                     sh 'mkdir -p ${WORKSPACE_SCRIPTS}'
                     sh 'cp ${MAVEN_WORKSPACE_SCRIPTS}/deploy-rcp.sh ${WORKSPACE_SCRIPTS}'

--- a/jenkins/pipelines/tracecompass-jdk17-mvn38.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-jdk17-mvn38.Jenkinsfile
@@ -48,11 +48,11 @@ pipeline {
                     sh 'cp scripts/deploy-javadoc.sh ${MAVEN_WORKSPACE_SCRIPTS}'
                     checkout([
                         $class: 'GitSCM',
-                        branches: [[name: '$GERRIT_BRANCH_NAME']],
+                        branches: [[name: '*/$GERRIT_BRANCH_NAME']],
                         doGenerateSubmoduleConfigurations: false,
-                        extensions: [[$class: 'CleanCheckout']],
+                        extensions: [],
                         submoduleCfg: [],
-                        userRemoteConfigs: [[credentialsId: 'github-bot', url: '$GERRIT_REPOSITORY_URL']]
+                        userRemoteConfigs: [[credentialsId: 'github-bot', refspec: '+refs/heads/$GERRIT_BRANCH_NAME:refs/remotes/origin/$GERRIT_BRANCH_NAME', url: '$GERRIT_REPOSITORY_URL']]
                     ])
                     sh 'mkdir -p ${WORKSPACE_SCRIPTS}'
                     sh 'cp ${MAVEN_WORKSPACE_SCRIPTS}/deploy-rcp.sh ${WORKSPACE_SCRIPTS}'

--- a/jenkins/pipelines/tracecompass-jdk17.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-jdk17.Jenkinsfile
@@ -48,11 +48,11 @@ pipeline {
                     sh 'cp scripts/deploy-javadoc.sh ${MAVEN_WORKSPACE_SCRIPTS}'
                     checkout([
                         $class: 'GitSCM',
-                        branches: [[name: '$GERRIT_BRANCH_NAME']],
+                        branches: [[name: '*/$GERRIT_BRANCH_NAME']],
                         doGenerateSubmoduleConfigurations: false,
-                        extensions: [[$class: 'CleanCheckout']],
+                        extensions: [],
                         submoduleCfg: [],
-                        userRemoteConfigs: [[credentialsId: 'github-bot', url: '$GERRIT_REPOSITORY_URL']]
+                        userRemoteConfigs: [[credentialsId: 'github-bot', refspec: '+refs/heads/$GERRIT_BRANCH_NAME:refs/remotes/origin/$GERRIT_BRANCH_NAME', url: '$GERRIT_REPOSITORY_URL']]
                     ])
                     sh 'mkdir -p ${WORKSPACE_SCRIPTS}'
                     sh 'cp ${MAVEN_WORKSPACE_SCRIPTS}/deploy-rcp.sh ${WORKSPACE_SCRIPTS}'

--- a/jenkins/pipelines/tracecompass-sonar.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-sonar.Jenkinsfile
@@ -35,11 +35,11 @@ pipeline {
             steps {
                 checkout([
                     $class: 'GitSCM',
-                    branches: [[name: '$GERRIT_BRANCH_NAME']],
+                    branches: [[name: '*/$GERRIT_BRANCH_NAME']],
                     doGenerateSubmoduleConfigurations: false,
-                    extensions: [[$class: 'CleanCheckout']],
+                    extensions: [],
                     submoduleCfg: [],
-                    userRemoteConfigs: [[credentialsId: 'github-bot', url: '$GERRIT_REPOSITORY_URL']]
+                    userRemoteConfigs: [[credentialsId: 'github-bot', refspec: '+refs/heads/$GERRIT_BRANCH_NAME:refs/remotes/origin/$GERRIT_BRANCH_NAME', url: '$GERRIT_REPOSITORY_URL']]
                 ])
             }
         }

--- a/jenkins/pipelines/tracecompass-test.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-test.Jenkinsfile
@@ -51,11 +51,11 @@ pipeline {
                     sh 'cp scripts/deploy-javadoc.sh ${MAVEN_WORKSPACE_SCRIPTS}'
                     checkout([
                         $class: 'GitSCM',
-                        branches: [[name: '$GERRIT_BRANCH_NAME']],
+                        branches: [[name: '*/$GERRIT_BRANCH_NAME']],
                         doGenerateSubmoduleConfigurations: false,
-                        extensions: [[$class: 'CleanCheckout']],
+                        extensions: [],
                         submoduleCfg: [],
-                        userRemoteConfigs: [[credentialsId: 'github-bot', url: '$GERRIT_REPOSITORY_URL']]
+                        userRemoteConfigs: [[credentialsId: 'github-bot', refspec: '+refs/heads/$GERRIT_BRANCH_NAME:refs/remotes/origin/$GERRIT_BRANCH_NAME', url: '$GERRIT_REPOSITORY_URL']]
                     ])
                     sh 'mkdir -p ${WORKSPACE_SCRIPTS}'
                     sh 'cp ${MAVEN_WORKSPACE_SCRIPTS}/deploy-rcp.sh ${WORKSPACE_SCRIPTS}'


### PR DESCRIPTION
- Prefix provided branch name prefixed with */: */$GERRIT_BRANCH_NAME
- Create refspec from provided branch name to fetch only specific branch:
+refs/heads/$GERRIT_BRANCH_NAME:refs/remotes/origin/$GERRIT_BRANCH_NAME

Note: No need for setting GERRIT_REFSPEC in jenkins job anymore

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>