### PR TITLE
Add build parameter for specifying custom category.xml file

### DIFF
--- a/jenkins/pipelines/tracecompass-incubator-jdk17.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-incubator-jdk17.Jenkinsfile
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 Ericsson.
+ * Copyright (c) 2020, 2025 Ericsson.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -72,6 +72,16 @@ pipeline {
             steps {
                 container('tracecompass') {
                     sh "cp -f ${WORKSPACE}/rcp/org.eclipse.tracecompass.incubator.rcp.product/${params.PRODUCT_FILE} ${WORKSPACE}/rcp/org.eclipse.tracecompass.incubator.rcp.product/tracing.incubator.product"
+                }
+            }
+        }
+        stage('Update Site File') {
+            when {
+                not { expression { return params.UPDATE_SITE_FILE == null || params.UPDATE_SITE_FILE.isEmpty() } }
+            }
+            steps {
+                container('tracecompass') {
+                    sh "cp -f ${WORKSPACE}/common/org.eclipse.tracecompass.incubator.releng-site/${params.UPDATE_SITE_FILE} ${WORKSPACE}/common/org.eclipse.tracecompass.incubator.releng-site//category.xml"
                 }
             }
         }

--- a/jenkins/pipelines/tracecompass-jdk17-mvn38.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-jdk17-mvn38.Jenkinsfile
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Ericsson.
+ * Copyright (c) 2023, 2025 Ericsson.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -79,6 +79,16 @@ pipeline {
             steps {
                 container('tracecompass') {
                     sh "cp -f ${WORKSPACE}/rcp/org.eclipse.tracecompass.rcp/${params.RCP_FEATURE_FILE} ${WORKSPACE}/rcp/org.eclipse.tracecompass.rcp/feature.xml"
+                }
+            }
+        }
+        stage('Update Site File') {
+            when {
+                not { expression { return params.UPDATE_SITE_FILE == null || params.UPDATE_SITE_FILE.isEmpty() } }
+            }
+            steps {
+                container('tracecompass') {
+                    sh "cp -f ${WORKSPACE}/releng/org.eclipse.tracecompass.releng-site/${params.UPDATE_SITE_FILE} ${WORKSPACE}/releng/org.eclipse.tracecompass.releng-site/category.xml"
                 }
             }
         }

--- a/jenkins/pipelines/tracecompass-jdk17.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-jdk17.Jenkinsfile
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 Ericsson.
+ * Copyright (c) 2019, 2025 Ericsson.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -82,6 +82,16 @@ pipeline {
             steps {
                 container('tracecompass') {
                     sh "cp -f ${WORKSPACE}/rcp/org.eclipse.tracecompass.rcp/${params.RCP_FEATURE_FILE} ${WORKSPACE}/rcp/org.eclipse.tracecompass.rcp/feature.xml"
+                }
+            }
+        }
+        stage('Update Site File') {
+            when {
+                not { expression { return params.UPDATE_SITE_FILE == null || params.UPDATE_SITE_FILE.isEmpty() } }
+            }
+            steps {
+                container('tracecompass') {
+                    sh "cp -f ${WORKSPACE}/releng/org.eclipse.tracecompass.releng-site/${params.UPDATE_SITE_FILE} ${WORKSPACE}/releng/org.eclipse.tracecompass.releng-site/category.xml"
                 }
             }
         }

--- a/jenkins/pipelines/tracecompass-jdk21.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-jdk21.Jenkinsfile
@@ -85,6 +85,16 @@ pipeline {
                 }
             }
         }
+        stage('Update Site File') {
+            when {
+                not { expression { return params.UPDATE_SITE_FILE == null || params.UPDATE_SITE_FILE.isEmpty() } }
+            }
+            steps {
+                container('tracecompass') {
+                    sh "cp -f ${WORKSPACE}/releng/org.eclipse.tracecompass.releng-site/${params.UPDATE_SITE_FILE} ${WORKSPACE}/releng/org.eclipse.tracecompass.releng-site/category.xml"
+                }
+            }
+        }
         stage('SLF4J Properties Manifest') {
             when {
                 not { expression { return params.SLF4J_PROPERTIES_MANIFEST == null || params.SLF4J_PROPERTIES_MANIFEST.isEmpty() } }


### PR DESCRIPTION
This allows to build for older targets that need a modified category.xml file.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>