### PR TITLE
Fix module-docs build by using own ease.module.doclet.jar

### DIFF
--- a/jenkins/pipelines/tracecompass-incubator-jdk17.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-incubator-jdk17.Jenkinsfile
@@ -109,7 +109,7 @@ pipeline {
             steps {
                 container('tracecompass') {
                     withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
-                        sh 'curl https://ci.eclipse.org/ease/job/ease.build.nightly/lastSuccessfulBuild/artifact/ease.module.doclet.jar --output ease.module.doclet.jar'
+                        sh 'curl https://ci.eclipse.org/tracecompass/job/org.eclipse.ease.helpgenerator/lastSuccessfulBuild/artifact/ease.module.doclet.jar --output ease.module.doclet.jar'
                         sh 'mvn clean install -B -Dgpg.passphrase="${KEYRING_PASSPHRASE}" -Pdeploy-doc -Pmodule-docs -DdocDestination=${WORKSPACE}/doc/.temp -Pbuild-rcp -Dmaven.repo.local=/home/jenkins/.m2/repository --settings /home/jenkins/.m2/settings.xml ${MAVEN_ARGS}'
                         sh 'mkdir -p ${SITE_PATH}'
                         sh 'git rev-parse --short HEAD > ${SITE_PATH}/${GIT_SHA_FILE}'

--- a/jenkins/pipelines/tracecompass-incubator-jdk21.Jenkinsfile
+++ b/jenkins/pipelines/tracecompass-incubator-jdk21.Jenkinsfile
@@ -109,7 +109,7 @@ pipeline {
             steps {
                 container('tracecompass') {
                     withCredentials([string(credentialsId: 'gpg-passphrase', variable: 'KEYRING_PASSPHRASE')]) {
-                        sh 'curl https://ci.eclipse.org/ease/job/ease.build.nightly/lastSuccessfulBuild/artifact/ease.module.doclet.jar --output ease.module.doclet.jar'
+                        sh 'curl https://ci.eclipse.org/tracecompass/job/org.eclipse.ease.helpgenerator/lastSuccessfulBuild/artifact/ease.module.doclet.jar --output ease.module.doclet.jar'
                         sh 'mvn clean install -B -Dgpg.passphrase="${KEYRING_PASSPHRASE}" -Pdeploy-doc -Pmodule-docs -DdocDestination=${WORKSPACE}/doc/.temp -Pbuild-rcp -Dmaven.repo.local=/home/jenkins/.m2/repository --settings /home/jenkins/.m2/settings.xml ${MAVEN_ARGS}'
                         sh 'mkdir -p ${SITE_PATH}'
                         sh 'git rev-parse --short HEAD > ${SITE_PATH}/${GIT_SHA_FILE}'


### PR DESCRIPTION
The ease.module.doclet.jar used to be provided by the EASE project's jenkins job: https://ci.eclipse.org/ease/job/ease.build.nightly/ However, it's currently not accessible and the EASE project has not fixed it.

To fix this, the Trace Compass project build the doclet on its CI. This commit change the incbuator pipline to download it from the dedicated Trace Compass CI job:
https://ci.eclipse.org/tracecompass/job/org.eclipse.ease.helpgenerator/

